### PR TITLE
enhance reason for requeue

### DIFF
--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -142,8 +143,10 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		// check pod count if dispatched for a while
 		if isSlowDispatching(appWrapper) && counts.Running+counts.Succeeded < int(appWrapper.Spec.Scheduling.MinAvailable) {
+
+			customMessage := "expected pods " + strconv.Itoa(int(appWrapper.Spec.Scheduling.MinAvailable)) + " but found pods " + strconv.Itoa(counts.Running+counts.Succeeded)
 			// requeue or fail if max retries exhausted
-			return r.requeueOrFail(ctx, appWrapper, "too few pods")
+			return r.requeueOrFail(ctx, appWrapper, customMessage)
 		}
 		// check for successful completion by looking at pods and wrapped resources
 		success, err := r.isSuccessful(ctx, appWrapper, counts)

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -145,7 +145,7 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if isSlowDispatching(appWrapper) && counts.Running+counts.Succeeded < int(appWrapper.Spec.Scheduling.MinAvailable) {
 
 			customMessage := "expected pods " + strconv.Itoa(int(appWrapper.Spec.Scheduling.MinAvailable)) + " but found pods " + strconv.Itoa(counts.Running+counts.Succeeded)
-			// requeue or fail if max retries exhausted
+			// requeue or fail if max retries exhausted with custom error message
 			return r.requeueOrFail(ctx, appWrapper, customMessage)
 		}
 		// check for successful completion by looking at pods and wrapped resources


### PR DESCRIPTION
The new re-queue message:

```
  Restarts:            2
  State:               Running
  Transitions:
    State:   Pending
    Time:    2023-10-10T19:11:08Z
    State:   Dispatching
    Time:    2023-10-10T19:11:08Z
    State:   Running
    Time:    2023-10-10T19:11:08Z
    Reason:  expected pods 3 but found pods 2
    State:   Requeuing
    Time:    2023-10-10T19:16:08Z
    State:   Pending
    Time:    2023-10-10T19:16:09Z
    State:   Dispatching
    Time:    2023-10-10T19:16:09Z
    State:   Running
    Time:    2023-10-10T19:16:09Z
    Reason:  expected pods 3 but found pods 2
    State:   Requeuing
    Time:    2023-10-10T19:21:14Z
    State:   Pending
    Time:    2023-10-10T19:21:14Z
    State:   Dispatching
    Time:    2023-10-10T19:21:14Z
    State:   Running
    Time:    2023-10-10T19:21:14Z
```