### PR TITLE
Fix inconsistencies between MCAD and MicroMCAD

### DIFF
--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -57,7 +57,7 @@ type AppWrapperStatus struct {
 	Phase AppWrapperPhase `json:"state,omitempty"`
 
 	// Status of wrapped resources
-	Step AppWrapperStep `json:"step"`
+	Step AppWrapperStep `json:"step,omitempty"`
 
 	// When last dispatched
 	DispatchTimestamp metav1.Time `json:"dispatchTimestamp,omitempty"`
@@ -135,7 +135,7 @@ type AppWrapperTransition struct {
 	Phase AppWrapperPhase `json:"state"`
 
 	// Status of wrapped resources
-	Step AppWrapperStep `json:"step"`
+	Step AppWrapperStep `json:"step,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -56,6 +56,9 @@ type AppWrapperStatus struct {
 	// Phase
 	Phase AppWrapperPhase `json:"state,omitempty"`
 
+	// Status of wrapped resources
+	Step AppWrapperStep `json:"step"`
+
 	// When last dispatched
 	DispatchTimestamp metav1.Time `json:"dispatchTimestamp,omitempty"`
 
@@ -72,27 +75,20 @@ type AppWrapperStatus struct {
 // AppWrapperPhase is the label for the AppWrapper status
 type AppWrapperPhase string
 
+// AppWrapperState is the status of wrapped resources
+type AppWrapperStep string
+
 const (
-	// no resource reservation
-	Empty AppWrapperPhase = ""
-
-	// no resource reservation
-	Queued AppWrapperPhase = "Pending"
-
-	// resources are reserved
-	Dispatching AppWrapperPhase = "Dispatching"
-
-	// resources are reserved
-	Running AppWrapperPhase = "Running"
-
-	// no resource reservation
+	Empty     AppWrapperPhase = ""
+	Queued    AppWrapperPhase = "Pending"
+	Running   AppWrapperPhase = "Running"
 	Succeeded AppWrapperPhase = "Completed"
+	Failed    AppWrapperPhase = "Failed"
 
-	// resources are reserved (some pods may still be running)
-	Failed AppWrapperPhase = "Failed"
-
-	// resources are reserved (some pods may still be running)
-	Requeuing AppWrapperPhase = "Requeuing"
+	Idle     AppWrapperStep = ""
+	Creating AppWrapperStep = "creating"
+	Created  AppWrapperStep = "created"
+	Deleting AppWrapperStep = "deleting"
 )
 
 // AppWrapper resources
@@ -137,6 +133,9 @@ type AppWrapperTransition struct {
 
 	// Phase entered
 	Phase AppWrapperPhase `json:"state"`
+
+	// Status of wrapped resources
+	Step AppWrapperStep `json:"step"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/appwrapper_types.go
+++ b/api/v1beta1/appwrapper_types.go
@@ -47,6 +47,13 @@ type SchedulingSpec struct {
 }
 
 type RequeuingSpec struct {
+	// Initial waiting time before requeuing conditions are checked
+	// +kubebuilder:default=300
+	TimeInSeconds int64 `json:"timeInSeconds,omitempty"`
+
+	// Wait time before trying to dispatch again after requeuing
+	PauseTimeInSeconds int64 `json:"pauseTimeInSeconds,omitempty"`
+
 	// Max requeuings permitted
 	MaxNumRequeuings int32 `json:"maxNumRequeuings,omitempty"`
 }
@@ -79,15 +86,31 @@ type AppWrapperPhase string
 type AppWrapperStep string
 
 const (
-	Empty     AppWrapperPhase = ""
-	Queued    AppWrapperPhase = "Pending"
-	Running   AppWrapperPhase = "Running"
-	Succeeded AppWrapperPhase = "Completed"
-	Failed    AppWrapperPhase = "Failed"
+	// Initial state upon creation of the AppWrapper object
+	Empty AppWrapperPhase = ""
 
-	Idle     AppWrapperStep = ""
+	// AppWrapper has not been dispatched yet or has been requeued
+	Queued AppWrapperPhase = "Pending"
+
+	// AppWrapper has been dispatched and not requeued
+	Running AppWrapperPhase = "Running"
+
+	// AppWrapper completed successfully
+	Succeeded AppWrapperPhase = "Completed"
+
+	// AppWrapper failed and is not requeued
+	Failed AppWrapperPhase = "Failed"
+
+	// Resources are not deployed
+	Idle AppWrapperStep = ""
+
+	// MCAD is in the process of creating the wrapped resources
 	Creating AppWrapperStep = "creating"
-	Created  AppWrapperStep = "created"
+
+	// The wrapped resources have been deployed successfully
+	Created AppWrapperStep = "created"
+
+	// MCAD is in the process of deleting the wrapped resources
 	Deleting AppWrapperStep = "deleting"
 )
 

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -173,13 +173,11 @@ spec:
                       type: string
                   required:
                   - state
-                  - step
                   - time
                   type: object
                 type: array
             required:
             - restarts
-            - step
             type: object
         type: object
     served: true

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -150,6 +150,9 @@ spec:
               state:
                 description: Phase
                 type: string
+              step:
+                description: Status of wrapped resources
+                type: string
               transitions:
                 description: Transition log
                 items:
@@ -161,17 +164,22 @@ spec:
                     state:
                       description: Phase entered
                       type: string
+                    step:
+                      description: Status of wrapped resources
+                      type: string
                     time:
                       description: Timestamp
                       format: date-time
                       type: string
                   required:
                   - state
+                  - step
                   - time
                   type: object
                 type: array
             required:
             - restarts
+            - step
             type: object
         type: object
     served: true

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -127,6 +127,17 @@ spec:
                         description: Max requeuings permitted
                         format: int32
                         type: integer
+                      pauseTimeInSeconds:
+                        description: Wait time before trying to dispatch again after
+                          requeuing
+                        format: int64
+                        type: integer
+                      timeInSeconds:
+                        default: 300
+                        description: Initial waiting time before requeuing conditions
+                          are checked
+                        format: int64
+                        type: integer
                     type: object
                 type: object
             required:

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -103,7 +103,7 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		// remove AppWrapper from cache
 		r.deleteCachedPhase(appWrapper)
-		log.FromContext(ctx).Info("Deleted", "state", "Deleted")
+		log.FromContext(ctx).Info("Deleted")
 		return ctrl.Result{}, nil
 	}
 
@@ -230,7 +230,7 @@ func (r *AppWrapperReconciler) updateStatus(ctx context.Context, appWrapper *mca
 	}
 	// cache AppWrapper status
 	r.addCachedPhase(appWrapper)
-	log.FromContext(ctx).Info(string(phase), "state", string(phase))
+	log.FromContext(ctx).Info(string(phase), "state", phase, "step", step)
 	return ctrl.Result{}, nil
 }
 

--- a/internal/controller/dispatch_logic.go
+++ b/internal/controller/dispatch_logic.go
@@ -81,7 +81,7 @@ func (r *AppWrapperReconciler) listAppWrappers(ctx context.Context) (map[int]Wei
 		if requests[int(appWrapper.Spec.Priority)] == nil {
 			requests[int(appWrapper.Spec.Priority)] = Weights{}
 		}
-		if isActivePhase(phase) {
+		if appWrapper.Status.Step != mcadv1beta1.Idle {
 			// discount resource requested by AppWrapper
 			awRequest := aggregateRequests(&appWrapper)
 			requests[int(appWrapper.Spec.Priority)].Add(awRequest)
@@ -174,15 +174,5 @@ func assertPriorities(w map[int]Weights) {
 	sort.Ints(keys)
 	for i := len(keys) - 1; i > 0; i-- {
 		w[keys[i-1]].Add(w[keys[i]])
-	}
-}
-
-// Are resources reserved in this phase
-func isActivePhase(phase mcadv1beta1.AppWrapperPhase) bool {
-	switch phase {
-	case mcadv1beta1.Dispatching, mcadv1beta1.Running, mcadv1beta1.Failed, mcadv1beta1.Requeuing:
-		return true
-	default:
-		return false // Empty, Queued, Succeeded
 	}
 }

--- a/internal/controller/timings.go
+++ b/internal/controller/timings.go
@@ -24,8 +24,7 @@ import (
 
 const (
 	// Timeouts
-	requeuingTimeout     = 2 * time.Minute // minimum wait before aborting Requeuing
-	runningTimeout       = 5 * time.Minute // minimum wait before aborting Running
+	deletionTimeout      = 2 * time.Minute // minimum wait before forcing deletion
 	cacheConflictTimeout = 5 * time.Minute // minimum wait before invalidating the cache
 	clusterInfoTimeout   = time.Minute     // how often to refresh cluster capacity
 

--- a/test/e2e/00-assert.yaml
+++ b/test/e2e/00-assert.yaml
@@ -5,6 +5,8 @@ metadata:
 status:
   transitions:
   - state: Pending
-  - state: Dispatching
   - state: Running
+    step: creating
+  - state: Running
+    step: created
   state: Running

--- a/test/e2e/01-assert.yaml
+++ b/test/e2e/01-assert.yaml
@@ -5,6 +5,8 @@ metadata:
 status:
   transitions:
   - state: Pending
-  - state: Dispatching
   - state: Running
+    step: creating
+  - state: Running
+    step: created
   state: Running

--- a/test/e2e/02-assert.yaml
+++ b/test/e2e/02-assert.yaml
@@ -5,7 +5,9 @@ metadata:
 status:
   transitions:
   - state: Pending
-  - state: Dispatching
   - state: Running
+    step: creating
+  - state: Running
+    step: created
   - state: Completed
   state: Completed

--- a/test/e2e/03-assert.yaml
+++ b/test/e2e/03-assert.yaml
@@ -5,7 +5,9 @@ metadata:
 status:
   transitions:
   - state: Pending
-  - state: Dispatching
   - state: Running
+    step: creating
+  - state: Running
+    step: created
   - state: Completed
   state: Completed

--- a/test/e2e/05-assert.yaml
+++ b/test/e2e/05-assert.yaml
@@ -5,7 +5,9 @@ metadata:
 status:
   transitions:
   - state: Pending
-  - state: Dispatching
   - state: Running
+    step: creating
+  - state: Running
+    step: created
   - state: Completed
   state: Completed


### PR DESCRIPTION
Fix inconsistencies between MCAD and MicroMCAD:
- reduce the number of AppWrapper states
- fix MinAvailable == 0 and MaxNumRequeuings == 0 behaviors
- add TimeInSeconds in RequeuingSpec

Introduce configurable pause time before redispatching requeued AppWrapper:
- add PauseTimeInSeconds in RequeuingSpec